### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,13 @@ const normalizeObject = pkg => {
   const clean = {}
   let hasBins = false
   Object.keys(orig).forEach(binKey => {
-    const base = join('/', basename(binKey.replace(/\\|:/g, '/'))).substr(1)
+    const base = join('/', basename(binKey.replace(/\\|:/g, '/'))).slice(1)
 
     if (typeof orig[binKey] !== 'string' || !base)
       return
 
     const binTarget = join('/', orig[binKey])
-      .replace(/\\/g, '/').substr(1)
+      .replace(/\\/g, '/').slice(1)
 
     if (!binTarget)
       return


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.