### PR TITLE
fix: apply slash normalizer before bin path join

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ const normalizeObject = pkg => {
       return
     }
 
-    const binTarget = join('/', orig[binKey])
+    const binTarget = join('/', orig[binKey].replace(/\\/g, '/'))
       .replace(/\\/g, '/').slice(1)
 
     if (!binTarget) {

--- a/test/array.js
+++ b/test/array.js
@@ -39,3 +39,10 @@ t.test('dotty array', async t => {
   t.strictSame(normalize(pkg), expect)
   t.strictSame(normalize(normalize(pkg)), expect, 'double sanitize ok')
 })
+
+t.test('dotty array with backslashes', async t => {
+  const pkg = { name: 'hello', version: 'world', bin: ['..\\..\\..\\..\\etc\\passwd'] }
+  const expect = { name: 'hello', version: 'world', bin: { passwd: 'etc/passwd' } }
+  t.strictSame(normalize(pkg), expect)
+  t.strictSame(normalize(normalize(pkg)), expect, 'double sanitize ok')
+})

--- a/test/string.js
+++ b/test/string.js
@@ -22,6 +22,13 @@ t.test('dotty string', async t => {
   t.strictSame(normalize(normalize(pkg)), expect, 'double sanitize ok')
 })
 
+t.test('dotty string with backslashes', async t => {
+  const pkg = { name: 'hello', version: 'world', bin: '..\\..\\..\\..\\etc\\passwd' }
+  const expect = { name: 'hello', version: 'world', bin: { hello: 'etc/passwd' } }
+  t.strictSame(normalize(pkg), expect)
+  t.strictSame(normalize(normalize(pkg)), expect, 'double sanitize ok')
+})
+
 t.test('double path', async t => {
   const pkg = { name: 'hello', version: 'world', bin: '/etc/passwd:/bin/usr/exec' }
   const expect = { name: 'hello', version: 'world', bin: { hello: 'etc/passwd:/bin/usr/exec' } }


### PR DESCRIPTION
## What / Why
Prevent pkg from linking binaries outside of its own directory

## Current behaviour
`'../../../../etc/passwd'` → `'etc/passwd'`
`'..\\..\\..\\..\\etc\\passwd'` → `'../../../../etc/passwd'`

## Expected
`'../../../../etc/passwd'` → `'etc/passwd'`
`'..\\..\\..\\..\\etc\\passwd'` → `'etc/passwd'`


