### PR TITLE
add .npmignore to ensure test files are not published.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/.git-blame-ignore-revs
 !/.github/
 !/.gitignore
+!/.npmignore
 !/.npmrc
 !/.prettierignore
 !/.prettierrc.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+# Test files
+test/
+*.test.js
+*.spec.js
+__tests__/
+coverage/
+
+# Development files
+.nyc_output/
+.tap/
+node_modules/


### PR DESCRIPTION
<!-- What / Why -->
We should not ship test files to npm itself.


## References
For example, these files are available when one installs this package as a dependency:
- /test/*
